### PR TITLE
feat: implement labwc session support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(GNUInstallDirs)
 
 option(ANACONDA_INITIAL_SETUP "Install configuration for Anaconda Initial Setup?" OFF)
 option(SDDM "Install configuration for SDDM?" ON)
+option(LABWC_DEVELOPMENT "Install desktop session file for labwc for development?" OFF)
 option(KWIN_DEVELOPMENT "Install desktop session file using KWin for development?" OFF)
 
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ There are a number of runtime requirements for various aspects of this project:
 
 ### Desktop
 
-This requires [Budgie Desktop] and [Magpie v1] (or optionally KWin's `kwin_wayland`).
-When using [KWin], KWin 6.0.0 or newer is required.
+This requires [Budgie Desktop] and [Magpie v1].
+
+Additionally, we make available sessions for labwc and Kwin (`kwin_wayland`). These are strictly for development / testing purposes and should not be considered officially supported by Buddies of Budgie. You will receive no assistance nor issue resolution for any compositor other than Magpie V1.
+
+- When using [labwc], 0.7.2 or newer is required.
+- When using [KWin], KWin 6.0.0 or newer is required.
 
 ### SDDM
 
@@ -31,10 +35,10 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 If a copy of the MPL was not distributed with this file, You can obtain one at
 https://mozilla.org/MPL/2.0/.
 
-
 [Budgie Desktop]: https://github.com/BuddiesOfBudgie/budgie-desktop
 [Magpie v1]: https://github.com/BuddiesOfBudgie/magpie/tree/v1
 [KWin]: https://invent.kde.org/plasma/kwin
 [SDDM]: https://github.com/sddm/sddm
 [Layer Shell Qt]: https://invent.kde.org/plasma/layer-shell-qt
 [Anaconda Initial Setup]: https://github.com/rhinstaller/initial-setup
+[labwc]: https://github.com/labwc/labwc

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -1,5 +1,9 @@
 install(FILES budgie-desktop-wayland.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/wayland-sessions)
 
+if (LABWC_DEVELOPMENT)
+install(FILES budgie-desktop-labwc.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/wayland-sessions)
+endif()
+
 if(KWIN_DEVELOPMENT)
 install(FILES budgie-desktop-kwinwayland.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/wayland-sessions)
 endif()

--- a/desktop/budgie-desktop-labwc.desktop
+++ b/desktop/budgie-desktop-labwc.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Budgie Desktop on labwc
+Comment=This session logs you into the Budgie Desktop
+Exec=/usr/bin/labwc --session=/usr/bin/budgie-desktop
+TryExec=/usr/bin/labwc
+Icon=
+Type=Application
+DesktopNames=Budgie;GNOME


### PR DESCRIPTION
I have validated that Budgie Desktop (Wayland) functions under labwc. This will add the respective session file for that support.