### PR TITLE
desktop/miriway: Ensure Xwayland DISPLAY variable is set properly

### DIFF
--- a/desktop/miriway/budgie-miriway-wrapper.in
+++ b/desktop/miriway/budgie-miriway-wrapper.in
@@ -18,6 +18,11 @@ then
   export MIR_SERVER_XWAYLAND_PATH
 fi
 
+# If enabling Xwayland, set up tmpfile to identify X11 DISPLAY
+if [ $MIR_SERVER_ENABLE_X11 -eq 1 ]; then
+    x11_display_file=$(mktemp --tmpdir="${XDG_RUNTIME_DIR}")
+fi
+
 export MIRIWAY_CONFIG_DIR="budgie"
 
 if [ ! -e "${XDG_CONFIG_HOME}/budgie/miriway-shell.config" ]; then
@@ -37,6 +42,22 @@ do
   fi
   inotifywait -qq --timeout 5 --event create "$(dirname "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}")"
 done
+
+# Grab the X11 DISPLAY and export it if needed
+if [ $MIR_SERVER_ENABLE_X11 -eq 1 ]; then
+  if inotifywait -qq --timeout 5 --event close_write "${x11_display_file}" && [ -s "${x11_display_file}" ]
+  then
+    # ${x11_display_file} contains the X11 display
+    DISPLAY=:$(cat "${x11_display_file}")
+    export DISPLAY
+    rm "${x11_display_file}"
+  else
+    echo "ERROR: Failed to get X11 display from miriway-shell [pid=${miriway-pid}]"
+    rm "${x11_display_file}"
+    kill ${miriway_pid}
+    exit 1
+  fi
+fi
 
 budgie-desktop "$@"
 budgie_desktop_exit_code=$?


### PR DESCRIPTION
This way X11 applications will function in the Budgie Miriway environment.