### PR TITLE
desktop/miriway: Add x11 displayfd arguments to miriway launch command

### DIFF
--- a/desktop/miriway/budgie-miriway-wrapper.in
+++ b/desktop/miriway/budgie-miriway-wrapper.in
@@ -29,7 +29,7 @@ if [ ! -e "${XDG_CONFIG_HOME}/budgie/miriway-shell.config" ]; then
     install -Dpm0644 "@CMAKE_INSTALL_FULL_DATADIR@/budgie-wayland-session/miriway-shell.config"  "${XDG_CONFIG_HOME}/budgie"
 fi
 
-miriway-shell --display-config=static="${XDG_CONFIG_HOME}/miriway-shell.display-config" --add-wayland-extensions=all &
+miriway-shell --display-config=static="${XDG_CONFIG_HOME}/miriway-shell.display-config" --add-wayland-extensions=all --x11-displayfd 5 5>${x11_display_file} &
 miriway_pid=$!
 
 # Wait until the server starts


### PR DESCRIPTION
This actually establishes the connection to the Xwayland server.

Fixes: 44a31a1a4285988fb08bf08a2ada9871213707d0